### PR TITLE
fix(Conversation): Fix typo in Conversation.update

### DIFF
--- a/src/AV.realtime.js
+++ b/src/AV.realtime.js
@@ -276,7 +276,7 @@ void function(win) {
                     }
                 };
                 cache.ec.on('conv-updated', fun);
-                engine.convUpate(options);
+                engine.convUpdate(options);
                 return this;
             }
         };


### PR DESCRIPTION
Fix a typo in `Conversation.update` which will block conversation attribute update.