### PR TITLE
对ie9中XDomainRequest执行不稳定，及ie9下第一个请求304时,xdr一直onerror

### DIFF
--- a/src/AV.realtime.js
+++ b/src/AV.realtime.js
@@ -448,7 +448,7 @@ void function(win) {
             if (win && win.location.protocol === 'https:' && secure) {
                 protocol = 'https://';
             }
-            url = protocol + 'router-g0-push.avoscloud.com/v1/route?r='+(new Date()).getTime()+'&appId=' + appId ;
+            url = protocol + 'router-g0-push.avoscloud.com/v1/route?_=' + tool.now() + '&appId=' + appId ;
             if (secure) {
               url += '&secure=1';
             }
@@ -1261,7 +1261,7 @@ void function(win) {
 
         xhr.onprogress = function(){}
         xhr.ontimeout = function(){}
-        xhr.timeout=0;
+        xhr.timeout = 0;
 
         var formData = '';
         if (options.form) {
@@ -1275,9 +1275,8 @@ void function(win) {
         } else {
             formData = JSON.stringify(options.data);
         }
-        setTimeout(function(){
-            xhr.send(formData);
-        }, 300);
+        
+        xhr.send(formData);
         
     };
 

--- a/src/AV.realtime.js
+++ b/src/AV.realtime.js
@@ -1259,6 +1259,10 @@ void function(win) {
             throw('Network error.');
         };
 
+        xhr.onprogress = function(){}
+        xhr.ontimeout = function(){}
+        xhr.timeout=0;
+
         var formData = '';
         if (options.form) {
             for (var k in options.data) {
@@ -1271,7 +1275,10 @@ void function(win) {
         } else {
             formData = JSON.stringify(options.data);
         }
-        xhr.send(formData);
+        setTimeout(function(){
+            xhr.send(formData);
+        }, 300);
+        
     };
 
     // 获取当前时间的时间戳

--- a/src/AV.realtime.js
+++ b/src/AV.realtime.js
@@ -448,7 +448,7 @@ void function(win) {
             if (win && win.location.protocol === 'https:' && secure) {
                 protocol = 'https://';
             }
-            url = protocol + 'router-g0-push.avoscloud.com/v1/route?appId=' + appId ;
+            url = protocol + 'router-g0-push.avoscloud.com/v1/route?r='+(new Date()).getTime()+'&appId=' + appId ;
             if (secure) {
               url += '&secure=1';
             }

--- a/src/AV.realtime.js
+++ b/src/AV.realtime.js
@@ -448,7 +448,7 @@ void function(win) {
             if (win && win.location.protocol === 'https:' && secure) {
                 protocol = 'https://';
             }
-            url = protocol + 'router-g0-push.avoscloud.com/v1/route?_=' + tool.now() + '&appId=' + appId ;
+            url = protocol + 'router-g0-push.avoscloud.com/v1/route?_t=' + tool.now() + '&appId=' + appId ;
             if (secure) {
               url += '&secure=1';
             }
@@ -1259,6 +1259,7 @@ void function(win) {
             throw('Network error.');
         };
 
+        // IE9 中需要设置所有的 xhr 事件回调，不然可能会无法执行后续操作
         xhr.onprogress = function(){}
         xhr.ontimeout = function(){}
         xhr.timeout = 0;


### PR DESCRIPTION
ie9问题参考如下：
https://social.msdn.microsoft.com/Forums/ie/en-US/30ef3add-767c-4436-b8a9-f1ca19b4812e/ie9-rtm-xdomainrequest-issued-requests-may-abort-if-all-event-handlers-not-specified?forum=iewebdevelopment

304问题是查了很久才发现的。