### PR TITLE
[feat] make secure option decided ws/wss only

### DIFF
--- a/src/realtime.js
+++ b/src/realtime.js
@@ -742,7 +742,7 @@ engine.getServer = function(cache, options, callback) {
   var secure = options.secure;
   var url = '';
   var protocol = 'http://';
-  if (global.location && global.location.protocol === 'https:' && secure) {
+  if (global.location && global.location.protocol === 'https:') {
     protocol = 'https://';
   }
   var node = '';


### PR DESCRIPTION
Option `ssl` only decided whether to use websocket over SSL. Router protocol is no longer configable.