### PR TITLE
feat(Realtime): Add event retry and schedule

### DIFF
--- a/src/realtime.js
+++ b/src/realtime.js
@@ -239,10 +239,11 @@ export default class Realtime extends EventEmitter {
    * @return {Promise.<IMClient>}
    */
   createIMClient(id, clientOptions, tag) {
-    if (id && this._clients[id] !== undefined) {
+    const idIsString = typeof id === 'string';
+    if (idIsString && this._clients[id] !== undefined) {
       return Promise.resolve(this._clients[id]);
     }
-    this._clients[id] = this._open().then(connection => {
+    const promise = this._open().then(connection => {
       const client = new IMClient(id, clientOptions, connection, {
         _messageParser: this._messageParser,
       });
@@ -254,7 +255,10 @@ export default class Realtime extends EventEmitter {
           return client;
         });
     });
-    return this._clients[id];
+    if (idIsString) {
+      this._clients[id] = promise;
+    }
+    return promise;
   }
 
   createPushClient() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,6 +67,16 @@ export const difference = (a, b) => Array.from(
   (bSet => new Set(a.filter(x => !bSet.has(x))))(new Set(b))
 );
 
+const map = new WeakMap();
+
+// protected property helper
+export const internal = (object) => {
+  if (!map.has(object)) {
+    map.set(object, {});
+  }
+  return map.get(object);
+};
+
 // debug utility
 const removeNull = obj => {
   if (!isPlainObject(obj)) return obj;

--- a/test/websocket-plus.js
+++ b/test/websocket-plus.js
@@ -50,9 +50,13 @@ describe('WebSocketPlus', () => {
     it('should reconnect when closed', () => {
       const disconnectCallback = sinon.spy();
       ws.on('disconnect', disconnectCallback);
+      const retryCallback = sinon.spy();
+      ws.on('retry', retryCallback);
       ws._ws.close();
       return listen(ws, 'reconnect').then(() => {
         disconnectCallback.should.be.calledOnce();
+        retryCallback.should.be.calledOnce();
+        retryCallback.should.be.calledWith(0);
         ws.is('connected').should.be.true();
       });
     });


### PR DESCRIPTION
目前的 SDK 只暴露了 `disconnect` 与 `reconnect` 两个事件，无法满足更加精细的断线重连提示。举个例子，bearychat 断线后会显示：

>7 秒后重新连接 ··· 立即重连
>正在重新连接 ···

这个 RP 为 WebSocketPlus 增加了 `reconnecting` 状态与 `schedule` 事件，为 Realtime 增加了 `retry` 方法，调用该方法会立即重连并重置尝试计数器。

更新后的 WebSocketPlus 状态转移描述如下：

![websocketplus](https://cloud.githubusercontent.com/assets/175227/14844892/49b03e00-0c8d-11e6-81f9-7839701cf423.png)


在一个典型的断线重连流程中，Realtime 实例会依次派发以下事件：
```
disconnect
schedule (attempt=0, delay=1000)
retry (attempt=0)
schedule (attempt=1, delay=2000)
retry (attempt=1)
schedule (attempt=2, delay=4000)
[call realtime.retry()]
retry (attempt=0)
schedule (attempt=1, delay=2000)
retry (attempt=1)
reconnect
```

cc @leancloud/ios-group @leancloud/android-group 