### PR TITLE
fix(TypedMessages): add support to AMD loaders

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,7 +88,8 @@ var require = require || function(id) {throw new Error('Unexpected required ' + 
             env(),
           ],
           format: 'umd',
-          moduleName: 'AV'
+          moduleName: 'AV',
+          moduleId: 'leancloud-realtime',
         }
       },
       test: {
@@ -102,6 +103,8 @@ var require = require || function(id) {throw new Error('Unexpected required ' + 
                 'proto/*.js',
                 'typed-messages/test/*.js',
                 'typed-messages/src/index.js',
+                'typed-messages/src/storage.js',
+                'typed-messages/src/realtime.js',
                 '*.json',
               ],
               instrumenter: require('istanbul'),
@@ -155,7 +158,13 @@ var require = require || function(id) {throw new Error('Unexpected required ' + 
             }),
           ],
           format: 'umd',
-          moduleName: 'AV'
+          moduleName: 'AV',
+          moduleId: 'typed-messages',
+          external: ['leancloud-realtime', 'avoscloud-sdk'],
+          globals: {
+            'leancloud-realtime': 'AV',
+            'avoscloud-sdk': 'AV',
+          },
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://leancloud.cn/",
   "devDependencies": {
-    "avoscloud-sdk": "1.0.0-rc8",
+    "avoscloud-sdk": "1.0.0-rc9",
     "babel-eslint": "^6.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-classes": "^6.5.2",

--- a/typed-messages/src/file-message.js
+++ b/typed-messages/src/file-message.js
@@ -25,8 +25,8 @@ export const FileMessage = inherit(TypedMessage, /** @lends FileMessage.prototyp
     this._file = file;
     this._lcfile = {
       objId: file.id,
-      url: file._url,
-      metaData: Object.assign(file._metaData || {}, {
+      url: file.url(),
+      metaData: Object.assign(file.metaData() || {}, {
         name: file.name(),
       }),
     };
@@ -48,10 +48,11 @@ export const FileMessage = inherit(TypedMessage, /** @lends FileMessage.prototyp
       id = '';
     }
     const file = File.createWithoutData(id);
-    file._url = data._lcfile.url;
-    file._metaData = data._lcfile.metaData;
+    file.attributes = file.attributes || {};
+    file._url = file.attributes.url = data._lcfile.url;
+    file._metaData = file.attributes.metaData = data._lcfile.metaData || {};
     if (data._lcfile.metaData) {
-      file._name = data._lcfile.metaData.name;
+      file._name = file.attributes.name = data._lcfile.metaData.name;
     }
     return file;
   },

--- a/typed-messages/src/realtime.js
+++ b/typed-messages/src/realtime.js
@@ -1,17 +1,12 @@
-/* global AV */
-let Realtime;
-if (typeof AV === 'object' && AV.TypedMessage) {
-  Realtime = AV;
-} else if (typeof require === 'function') {
-  try {
-    Realtime = require('leancloud-realtime'); // eslint-disable-line
-  } catch (e) {
-    throw new Error('peerDependency \'leancloud-realtime\' not found, install it first');
-  }
-} else {
-  throw new Error('AV.Realtime not exists, import LeanCloud Realtime SDK first');
+/* eslint-disable import/no-unresolved */
+import { TypedMessage } from 'leancloud-realtime';
+
+if (!TypedMessage) {
+  throw new Error('LeanCloud Realtime SDK not installed');
 }
 
-export const TypedMessage = Realtime.TypedMessage;
-export const messageType = Realtime.messageType;
-export const messageField = Realtime.messageField;
+export {
+  TypedMessage,
+  messageType,
+  messageField,
+} from 'leancloud-realtime';

--- a/typed-messages/src/storage.js
+++ b/typed-messages/src/storage.js
@@ -1,16 +1,11 @@
-/* global AV */
-let Storage;
-if (typeof AV === 'object' && AV.File) {
-  Storage = AV;
-} else if (typeof require === 'function') {
-  try {
-    Storage = require('avoscloud-sdk'); // eslint-disable-line
-  } catch (e) {
-    throw new Error('peerDependency \'avoscloud-sdk\' not found, install it first');
-  }
-} else {
-  throw new Error('detect AV failed, import LeanCloud Storage SDK first');
+/* eslint-disable import/no-unresolved */
+import { File } from 'avoscloud-sdk';
+
+if (!File) {
+  throw new Error('LeanCloud Storage SDK not installed');
 }
 
-export const File = Storage.File;
-export const GeoPoint = Storage.GeoPoint;
+export {
+  File,
+  GeoPoint,
+} from 'avoscloud-sdk';


### PR DESCRIPTION
使用了 rollup 内置的外部依赖加载方式代替自己写的加载器从而添加了 AMD loaders 的支持。
兼容 SDK 1.0.0-rc.9 的 AV.File 数据结构。