### PR TITLE
fix(WebSocketPlus): check connection state when calling #send

### DIFF
--- a/.jsdocrc.json
+++ b/.jsdocrc.json
@@ -1,5 +1,5 @@
 {
-  "options": {
+  "opts": {
     "template": "node_modules/docdash"
   },
   "plugins": ["node_modules/jsdoc-ignore-future"],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,7 +198,7 @@ var require = require || function(id) {throw new Error('Unexpected required ' + 
       tasks = tasks.concat(['connect', 'saucelabs-mocha']);
     } else {
       grunt.log.writeln('Saucelabs test skipped, set SAUCE_USERNAME and SAUCE_ACCESS_KEY to start it.');
-      grunt.log.writeln('If you want to run browser tests locally, start a static server then run ./test/browser/');
+      grunt.log.writeln('To run browser tests locally, start a static server then run ./test/browser/');
     }
     grunt.task.run(tasks);
   });

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm run convert-pb
 ```
 测试
 ```
-npm run test:node
+npm run test:node -- --grep KEYWORDS
 ```
 浏览器测试
 ```


### PR DESCRIPTION
Previously, if the connection is not connected, calling APIs invoking WebSocketPlus#send will throw `null is not an object(evaluating 'this._ws.send')`, which is not helping.
This commit decorate WebSocketPlus#send with connection state checking which throws meaningful error and warning.

cc @han4wluc