### PR TITLE
fix: stop assigning global WebSocket

### DIFF
--- a/src/browser/ws.js
+++ b/src/browser/ws.js
@@ -1,2 +1,2 @@
-// eslint-disable-next-line no-native-reassign
-export default WebSocket = global.WebSocket || global.MozWebSocket;
+const WebSocket = global.WebSocket || global.MozWebSocket;
+export default WebSocket;


### PR DESCRIPTION
Previously, globel.WebSocket was assigned accidentally(https://github.com/leancloud/js-realtime-sdk/blob/v3.0.0/dist/realtime.browser.js#L4243), which caused crashes in React Native as global.WebSocket is readonly.

fix #281.