### PR TITLE
feat(ConversationQuery): support more lastMessage metaData

### DIFF
--- a/src/im-client.js
+++ b/src/im-client.js
@@ -524,6 +524,9 @@ export default class IMClient extends Client {
       objectId: 'id',
       lm: 'lastMessageAt',
       msg: 'lastMessage',
+      msg_from: 'lastMessageFrom',
+      msg_mid: 'lastMessageId',
+      msg_timestamp: 'lastMessageTimestamp',
       m: 'members',
       attr: 'attributes',
       tr: 'transient',
@@ -532,6 +535,12 @@ export default class IMClient extends Client {
     }, rawData);
     if (data.lastMessage) {
       data.lastMessage = this._messageParser.parse(data.lastMessage);
+      data.lastMessage.from = data.lastMessageFrom;
+      data.lastMessage.id = data.lastMessageId;
+      data.lastMessage.timestamp = new Date(data.lastMessageTimestamp);
+      delete data.lastMessageFrom;
+      delete data.lastMessageId;
+      delete data.lastMessageTimestamp;
     }
     return new Conversation(data, this);
   }

--- a/test/conversation-query.js
+++ b/test/conversation-query.js
@@ -261,7 +261,11 @@ describe('ConversationQuery', () => {
       .find()
       .then(conversations => {
         conversations.length.should.be.equal(1);
-        conversations[0].lastMessage.should.be.instanceof(Message);
+        const message = conversations[0].lastMessage;
+        message.should.be.instanceof(Message);
+        message.from.should.be.ok();
+        message.id.should.be.ok();
+        message.timestamp.should.be.ok();
       })
   );
   it('withLastMessages should be proxied', () => {


### PR DESCRIPTION
when quering conversations with lastMessage flag, the lastMessage get the correct from/id/timestamp now.

https://leanticket.cn/t/leancloud/2105