### PR TITLE
feat(Message): implement message receipt

### DIFF
--- a/src/im-client.js
+++ b/src/im-client.js
@@ -18,6 +18,7 @@ import * as Errors from './errors';
 import { tap, Expirable, Cache, keyRemap, union, difference, trim, internal } from './utils';
 import { applyDecorators } from './plugin';
 import runSignatureFactory from './signature-factory-runner';
+import { MessageStatus } from './messages/message';
 import { version as VERSION } from '../package.json';
 
 const debug = d('LC:IMClient');
@@ -292,6 +293,7 @@ export default class IMClient extends Client {
         transient,
       };
       Object.assign(message, messageProps);
+      message._setStatus(MessageStatus.SENT);
       conversation.lastMessage = message; // eslint-disable-line no-param-reassign
       conversation.lastMessageAt = message.timestamp; // eslint-disable-line no-param-reassign
       conversation.unreadMessagesCount++; // eslint-disable-line no-param-reassign
@@ -582,6 +584,7 @@ export default class IMClient extends Client {
             data.lastMessage.from = data.lastMessageFrom;
             data.lastMessage.id = data.lastMessageId;
             data.lastMessage.timestamp = new Date(data.lastMessageTimestamp);
+            data.lastMessage._setStatus(MessageStatus.SENT);
             delete data.lastMessageFrom;
             delete data.lastMessageId;
             delete data.lastMessageTimestamp;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /** @module leancloud-realtime */
 import { default as Realtime } from './realtime';
-import { default as Message } from './messages/message';
+import Message, { MessageStatus } from './messages/message';
 import { default as TypedMessage } from './messages/typed-message';
 import { default as TextMessage } from './messages/text-message';
 import {
@@ -64,4 +64,5 @@ export {
    */
   messageField,
   IE10Compatible,
+  MessageStatus,
 };

--- a/src/messages/message.js
+++ b/src/messages/message.js
@@ -1,5 +1,34 @@
 import uuid from 'uuid';
 
+
+/**
+ * 消息状态枚举
+ * @enum {Symbol}
+ * @memberof module:leancloud-realtime
+ */
+const MessageStatus = {
+  /** 初始状态、未知状态 */
+  NONE: Symbol('none'),
+  /** 正在发送 */
+  SENDING: Symbol('sending'),
+  /** 已发送 */
+  SENT: Symbol('sent'),
+  /** 已送达 */
+  DELIVERED: Symbol('delivered'),
+  /** 发送失败 */
+  FAILED: Symbol('failed'),
+};
+Object.freeze(MessageStatus);
+
+const rMessageStatus = {
+  [MessageStatus.NONE]: true,
+  [MessageStatus.SENDING]: true,
+  [MessageStatus.SENT]: true,
+  [MessageStatus.DELIVERED]: true,
+  [MessageStatus.FAILED]: true,
+};
+
+export { MessageStatus };
 export default class Message {
   /**
    * @implements AVMessage
@@ -43,6 +72,7 @@ export default class Message {
        */
       transient: false,
     });
+    this._setStatus(MessageStatus.NONE);
   }
 
   /**
@@ -72,6 +102,22 @@ export default class Message {
    */
   toJSON() {
     return this.content;
+  }
+
+  /**
+   * 消息状态
+   * @type {}
+   * @readonly
+   */
+  get status() {
+    return this._status;
+  }
+
+  _setStatus(status) {
+    if (!rMessageStatus[status]) {
+      throw new Error('Invalid message status');
+    }
+    this._status = status;
   }
 
   /**

--- a/src/messages/message.js
+++ b/src/messages/message.js
@@ -71,12 +71,17 @@ export default class Message {
        * @type {Boolean}
        */
       transient: false,
+      /**
+       * @var deliveredAt {?Date} 消息送达时间
+       * @memberof Message#
+       */
+      // deliveredAt,
     });
     this._setStatus(MessageStatus.NONE);
   }
 
   /**
-   * 设置是否需要回执
+   * 设置是否需要送达回执
    * @param {Boolean} needReceipt
    * @return {Message} self
    */

--- a/src/realtime.js
+++ b/src/realtime.js
@@ -229,7 +229,7 @@ export default class Realtime extends EventEmitter {
     }
   }
 
-  static _fetchEndpointsInfo({ appId, region, ssl, _debug }) {
+  static _fetchEndpointsInfo({ appId, region, ssl, server }) {
     debug('fetch endpoint info');
     return this._fetchPushRouter({ appId, region })
       .then(tap(debug))
@@ -238,7 +238,7 @@ export default class Realtime extends EventEmitter {
           params: {
             appId,
             secure: ssl,
-            debug: _debug,
+            server,
             _t: Date.now(),
           },
           timeout: 20000,

--- a/test/conversation-query.js
+++ b/test/conversation-query.js
@@ -1,6 +1,6 @@
 import ConversationQuery from '../src/conversation-query';
 import Realtime from '../src/realtime';
-import Message from '../src/messages/message';
+import Message, { MessageStatus } from '../src/messages/message';
 
 import {
   APP_ID,
@@ -307,6 +307,7 @@ describe('ConversationQuery', () => {
           message.from.should.be.ok();
           message.id.should.be.ok();
           message.timestamp.should.be.ok();
+          message.status.should.be.eql(MessageStatus.SENT);
         })
     );
     it('withLastMessages should be proxied', () => {

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -5,7 +5,7 @@ import {
   GenericCommand,
   ConvCommand,
 } from '../proto/message';
-import Message from '../src/messages/message';
+import Message, { MessageStatus } from '../src/messages/message';
 import TextMessage from '../src/messages/text-message';
 
 import {
@@ -170,6 +170,7 @@ describe('Conversation', () => {
       conversation.queryMessages().then(messages => {
         messages.should.be.an.Array();
         messages[0].should.be.instanceof(Message);
+        messages[0].status.should.be.eql(MessageStatus.SENT);
       })
     );
     it('with limit', () =>

--- a/test/messages.js
+++ b/test/messages.js
@@ -11,6 +11,7 @@ import { listen } from './test-utils';
 import {
   APP_ID,
   REGION,
+  EXISTING_ROOM_ID,
 } from './configs';
 
 @messageType(1)
@@ -207,6 +208,17 @@ describe('Messages', () => {
         .then(() => {
           message.status.should.eql(MessageStatus.DELIVERED);
           message.deliveredAt.should.be.Date();
+        });
+    });
+    it('errors', () => {
+      (() => conversationWchen.send('1')).should.throw(/not a Message/);
+      const message = new Message('hello');
+      return wchen
+        .getConversation(EXISTING_ROOM_ID)
+        .then(conversation => conversation.send(message))
+        .should.be.rejected()
+        .then(() => {
+          message.status.should.eql(MessageStatus.FAILED);
         });
     });
   });

--- a/test/messages.js
+++ b/test/messages.js
@@ -198,5 +198,16 @@ describe('Messages', () => {
         msg.status.should.eql(MessageStatus.SENT);
       });
     });
+    it('receipt', () => {
+      const message = new TextMessage('message needs receipt');
+      const receiptPromise = listen(conversationZwang, 'receipt');
+      message.setNeedReceipt(true);
+      return conversationZwang.send(message)
+        .then(() => receiptPromise)
+        .then(() => {
+          message.status.should.eql(MessageStatus.DELIVERED);
+          message.deliveredAt.should.be.Date();
+        });
+    });
   });
 });

--- a/test/messages.js
+++ b/test/messages.js
@@ -1,7 +1,7 @@
 import 'should';
 import 'should-sinon';
 import Realtime from '../src/realtime';
-import Message from '../src/messages/message';
+import Message, { MessageStatus } from '../src/messages/message';
 import TypedMessage from '../src/messages/typed-message';
 import TextMessage from '../src/messages/text-message';
 import { messageType, messageField, IE10Compatible } from '../src/messages/helpers';
@@ -42,6 +42,28 @@ describe('Messages', () => {
       });
     });
   });
+
+  describe('message status', () => {
+    before(function () {
+      this.message = new Message();
+    });
+    it('should default to none', function () {
+      this.message.status.should.eql(MessageStatus.NONE);
+    });
+    it('should be readonly', function () {
+      (() => {
+        this.message.status = MessageStatus.SENT;
+      }).should.throw();
+    });
+    it('_setStatus should work', function () {
+      this.message._setStatus(MessageStatus.SENT);
+      this.message.status.should.eql(MessageStatus.SENT);
+    });
+    it('_setStatus should only accept MessageStatus', function () {
+      (() => this.message._setStatus(0)).should.throw(/Invalid/);
+    });
+  });
+
   describe('TextMessage', () => {
     it('param check', () => {
       (() => new TextMessage({})).should.throw(TypeError);
@@ -127,26 +149,31 @@ describe('Messages', () => {
       zwang.close(),
     ]));
 
-    it('sending message', () =>
-      Promise.all([
+    it('sending message', () => {
+      const message = new Message('hello');
+      const promise = Promise.all([
         listen(conversationZwang, 'message'),
         listen(zwang, 'message'),
-        conversationWchen.send(new Message('hello')),
+        conversationWchen.send(message),
       ]).then(messages => {
         const [
           [receivedMessage],
           [clientReceivedMessage, clientReceivedConversation],
           sentMessage,
         ] = messages;
+        sentMessage.status.should.eql(MessageStatus.SENT);
         receivedMessage.id.should.eql(sentMessage.id);
         receivedMessage.content.should.eql(sentMessage.content);
+        receivedMessage.status.should.eql(MessageStatus.SENT);
         clientReceivedMessage.id.should.eql(sentMessage.id);
         clientReceivedConversation.id.should.eql(conversationWchen.id);
         conversationZwang.lastMessage.content.should.eql(sentMessage.content);
         conversationWchen.lastMessage.content.should.eql(sentMessage.content);
         conversationZwang.unreadMessagesCount.should.eql(1);
-      })
-    );
+      });
+      message.status.should.eql(MessageStatus.SENDING);
+      return promise;
+    });
     it('sending typed message', () => {
       const receivePromise = listen(conversationZwang, 'message');
       const sendPromise = conversationWchen.send(
@@ -166,7 +193,10 @@ describe('Messages', () => {
       message.setTransient(true);
       // transient message 不返回 ack
       // 这里确保成功 resolve
-      return conversationZwang.send(message);
+      return conversationZwang.send(message).then(msg => {
+        msg.should.be.instanceof(Message);
+        msg.status.should.eql(MessageStatus.SENT);
+      });
     });
   });
 });


### PR DESCRIPTION
Add status property to Message and export MessageStatus: `NONE`, `SENDING`, `SENT`, `DELIVERED`, `FAILED`.

If set to `needReceipt`, a message will turn to `DELIVERED` status once it's delivered.
Also a `receipt` event will be emitted on the conversation the message was send to.