### PR TITLE
feat(Conversation): make get, set public and deprecate attributes setter APIs

### DIFF
--- a/src/conversation.js
+++ b/src/conversation.js
@@ -151,26 +151,32 @@ export default class Conversation extends EventEmitter {
   /**
    * 对话额外属性，对应 _Conversation 表中的 attr
    * @type {Object}
+   * @deprecated Use {@link Conversation#get conversation.get('attr')},
+   * {@link Conversation#set conversation.set('attr', value)} instead
    */
   get attributes() {
-    return this._get('attr');
+    console.warn('DEPRECATION Conversation.attributes: Use conversation.get(\'attr\') instead. See https://url.leanapp.cn/DeprecateAttributes for more details.');
+    return this.get('attr');
   }
   set attributes(value) {
-    this._set('attr', value);
+    console.warn('DEPRECATION Conversation.attributes: Use conversation.set(\'attr\', value) instead. See https://url.leanapp.cn/DeprecateAttributes for more details.');
+    this.set('attr', value);
   }
   /**
    * 设置对话额外属性
    * @param {Object} map    key-value 对
    * @param {Boolean} [assign=false] 使用 Object.assign 更新属性，而不是替换整个 attributes
    * @return {Conversation} self
+   * @deprecated Use {@link Conversation#set} instead. See {@link https://url.leanapp.cn/DeprecateAttributes} for more details.
    */
   setAttributes(map, assign = false) {
+    console.warn('DEPRECATION Conversation#setAttributes: Use conversation.set() instead. See https://url.leanapp.cn/DeprecateAttributes for more details.');
     this._debug(`set attributes: value=${JSON.stringify(map)}, assign=${assign}`);
     if (!isPlainObject(map)) {
       throw new TypeError('attributes must be a plain object');
     }
     if (!assign) {
-      this._set('attr', map);
+      this.set('attr', map);
     } else {
       Object.keys(map).forEach(key => this.setAttribute(key, map[key]));
     }
@@ -181,34 +187,60 @@ export default class Conversation extends EventEmitter {
    * @param {String} key
    * @param {Any} value
    * @return {Conversation} self
+   * @deprecated Use {@link Conversation#set conversation.set('attr.key', value)} instead
    */
   setAttribute(key, value) {
-    return this._set(`attr.${key}`, value);
+    console.warn('DEPRECATION Conversation#setAttribute: Use conversation.set(\'attr.key\', value) instead. See https://url.leanapp.cn/DeprecateAttributes for more details.');
+    return this.set(`attr.${key}`, value);
   }
   /**
    * 对话名字，对应 _Conversation 表中的 name
    * @type {String}
    */
   get name() {
-    return this._get('name');
+    return this.get('name');
   }
   set name(value) {
-    this._set('name', value);
+    this.set('name', value);
   }
   /**
    * 设置对话名字
    * @param {String} value
    * @return {Conversation} self
+   * @deprecated Use {@link Conversation#set conversation.set('name', value)} instead
    */
   setName(value) {
-    return this._set('name', value);
+    console.warn('DEPRECATION Conversation#setName: Use conversation.set(\'name\', value) instead. See https://url.leanapp.cn/DeprecateAttributes for more details.');
+    return this.set('name', value);
   }
 
-  _get(key) {
+  /**
+   * 获取对话的自定义属性
+   * @since 3.2.0
+   * @param  {String} key key 属性的键名，'x' 对应 Conversation 表中的 x 列
+   * @return {Any} 属性的值
+   */
+  get(key) {
     return internal(this).currentAttributes[key];
   }
 
-  _set(key, value) {
+  /**
+   * 设置对话的自定义属性
+   * @since 3.2.0
+   * @param {String} key 属性的键名，'x' 对应 Conversation 表中的 x 列，支持使用 'x.y.z' 来修改对象的部分字段。
+   * @param {Any} value 属性的值
+   * @return {Conversation} self
+   * @example
+   *
+   * // 设置对话的 color 属性
+   * conversation.set('color', {
+   *   text: '#000',
+   *   background: '#DDD',
+   * });
+   * // 设置对话的 color.text 属性
+   * conversation.set('color.text', '#333');
+   */
+  set(key, value) {
     this._debug(`set [${key}]: ${value}`);
     const pendingAttributes = internal(this).pendingAttributes;
     const pendingKeys = Object.keys(pendingAttributes);

--- a/src/realtime.js
+++ b/src/realtime.js
@@ -6,6 +6,7 @@ import Connection from './connection';
 import * as Errors from './errors';
 import { tap, Cache, trim, internal, ensureArray } from './utils';
 import { applyDecorators } from './plugin';
+import Conversation from './conversation';
 import Client from './client';
 import IMClient from './im-client';
 import MessageParser from './message-parser';
@@ -368,5 +369,29 @@ export default class Realtime extends EventEmitter {
    */
   register(messageClass) {
     return ensureArray(messageClass).map(this._messageParser.register.bind(this._messageParser));
+  }
+
+  /**
+   * 为 Conversation 定义一个新属性
+   * @static
+   * @param {String} prop 属性名
+   * @param {Object} [descriptor] 属性的描述符，参见 {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#Description getOwnPropertyDescriptor#Description - MDN}，默认为该属性名对应的 Conversation 自定义属性的 getter/setter
+   * @returns void
+   * @example
+   *
+   * // previous
+   * conversation.get('admin');
+   * conversation.set('admin', 'Tom');
+   *
+   * // equals to
+   * Realtime.defineConversationProperty('admin');
+   * conversation.admin;
+   * conversation.admin = 'Tom';
+   */
+  static defineConversationProperty(prop, descriptor = {
+    get() { return this.get(prop); },
+    set(value) { this.set(prop, value); },
+  }) {
+    Object.defineProperty(Conversation.prototype, prop, descriptor);
   }
 }

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -38,6 +38,15 @@ describe('Conversation', () => {
   });
   after(() => client.close());
 
+  it('defineConversationProperty', () => {
+    Realtime.defineConversationProperty('testProperty1');
+    conversation.set('testProperty1', 1);
+    conversation.testProperty1.should.eql(1);
+    Realtime.defineConversationProperty('testProperty2');
+    conversation.testProperty2 = 2;
+    conversation.get('testProperty2').should.eql(2);
+  });
+
   it('update', () => {
     const timestamp = Date.now();
     const name = conversation.name;


### PR DESCRIPTION
including: attributes setter and getter, setAttribute, setAttributes, setName

详细说明：https://url.leanapp.cn/DeprecateAttributes

also: add Realtime.defineConversationProperty to make it easy to define custom properties for Conversation

不想因此 export Conversation，所以这个 API 是 Realtime 的静态方法，不知道有没有更好的设计。