### PR TITLE
fix(WebSocketPlus): also catch error on close event

### DIFF
--- a/src/websocket-plus.js
+++ b/src/websocket-plus.js
@@ -65,7 +65,7 @@ class WebSocketPlus extends EventEmitter {
           ) : new WebSocket(url);
           ws.binaryType = this.binaryType || 'arraybuffer';
           ws.onopen = () => resolve(ws);
-          ws.onerror = error => {
+          ws.onerror = ws.onclose = error => {
             if (error instanceof Error) {
               return reject(error);
             }


### PR DESCRIPTION
In Safari, when air mode is on, the connecting failure can only be caught in onclose event.
Fix issue that the first reconnect attempt will be penging forever.