### PR TITLE
feat(WebSocketPlus): add new offline state

### DIFF
--- a/demo/simple-chatroom/test.js
+++ b/demo/simple-chatroom/test.js
@@ -49,7 +49,7 @@ bindEvent(document.body, 'keydown', function(e) {
 });
 
 function main() {
-  showLog('正在连接服务器，请等待。。。');
+  showLog('正在连接，请等待');
   var val = inputName.value;
   if (val) {
     clientId = val;
@@ -67,11 +67,29 @@ function main() {
   // 创建聊天客户端
   realtime.createIMClient(clientId)
   .then(function(c) {
-    showLog('服务器连接成功！');
+    showLog('连接成功');
     firstFlag = false;
     client = c;
     client.on('disconnect', function() {
-      showLog('服务器正在重连，请耐心等待。。。');
+      showLog('[disconnect] 服务器连接已断开');
+    });
+    client.on('offline', function() {
+      showLog('[offline] 离线（网络连接已断开）');
+    });
+    client.on('online', function() {
+      showLog('[online] 已恢复在线');
+    });
+    client.on('schedule', function(attempt, time) {
+      showLog('[schedule] ' + time / 1000 + 's 后进行第 ' + (attempt + 1) + ' 次重连');
+    });
+    client.on('retry', function(attempt) {
+      showLog('[retry] 正在进行第 ' + (attempt + 1) + ' 次重连');
+    });
+    client.on('reconnect', function() {
+      showLog('[reconnect] 重连成功');
+    });
+    client.on('reconnecterror', function() {
+      showLog('[reconnecterror] 重连失败');
     });
     // 获取对话
     return c.getConversation(roomId);
@@ -81,7 +99,7 @@ function main() {
       return conversation;
     } else {
       // 如果服务器端不存在这个 conversation
-      showLog('服务器不存在这个 conversation，创建一个。');
+      showLog('不存在这个 conversation，创建一个。');
       return client.createConversation({
         name: 'LeanCloud-Conversation',
         members: [


### PR DESCRIPTION
目前，SDK 连接层有下面几个状态：

![](https://cloud.githubusercontent.com/assets/175227/14844892/49b03e00-0c8d-11e6-81f9-7839701cf423.png)

有两个问题：

- 网络断开时，由于 WebSocket 实现内置有重连机制，SDK 不会立即感知到断开，而此时消息发送均会失败，这个过程有时会长达 3 分钟直到心跳检测失败。
- 在明确感知到网络断开的情况下，SDK 是不应该尝试重连的。

同样的问题在 React Native 或小程序应用前后台切换时也存在。参见 #421 https://forum.leancloud.cn/t/websocket/12774

为了解决这个问题，这个 PR 为 SDK 增加了一个 `offline` 状态（原来的 `offline` 状态改名为 `disconnected`）：

![](https://cloud.githubusercontent.com/assets/175227/21848435/a6d9c446-d83b-11e6-974b-baa2e1743bf1.png)


在浏览器上，SDK 通过监听 window 的 `offline`/`online` 事件，当网络断开时 pause SDK，网络恢复时 resume SDK 然后开始重连。用户可以通过 Realtime 或 IMClient 派发的 `offline`/`online` 事件在用户界面上作出相应的提示。改动后，一次断网恢复的过程中 SDK 会依次派发以下事件：

```
[offline] 离线（网络连接已断开）
[disconnect] 服务器连接已断开
[online] 已恢复在线
[schedule] 1s 后进行第 1 次重连
[retry] 正在进行第 1 次重连
[reconnect] 重连成功
```

对于 React Naitve 的网络变化、RN 与小程序的前后台切换以及其他的场景，Realtime 增加 `pause` 与 `resume` 方法供开发者手动控制 SDK 的离线状态。

close #421 