### PR TITLE
feat(Conversation): support read timestamp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,8 +49,8 @@
 * **Conversation:** `send` 方法新增参数 `options`，与消息内容无关的信息现在作为发送选项设置，可选的参数包括
   * `options.pushData`：离线推送内容
   * `options.priority`：聊天室消息的优先级
-  * `options.reciept`：是否需要送达回执
-* **Message:** 废弃了 `Message#setNeedReciept` 方法与 Message 的 `needReciept` 属性，推荐使用 `Conversation#send` 方法的 `options.reciept` 参数 ([a38c481](https://github.com/leancloud/js-realtime-sdk/commit/a38c481))
+  * `options.receipt`：是否需要送达回执
+* **Message:** 废弃了 `Message#setNeedReceipt` 方法与 Message 的 `needReceipt` 属性，推荐使用 `Conversation#send` 方法的 `options.receipt` 参数 ([a38c481](https://github.com/leancloud/js-realtime-sdk/commit/a38c481))
 * **Error:** 新增了 ErrorCode，用于判断捕获的异常 ([#353](https://github.com/leancloud/js-realtime-sdk/issues/353)) ([bbdf608](https://github.com/leancloud/js-realtime-sdk/commit/bbdf608))
 * 增加 TypeScript 定义文件 ([#373](https://github.com/leancloud/js-realtime-sdk/issues/373)) ([2e5da17](https://github.com/leancloud/js-realtime-sdk/commit/2e5da17))
 

--- a/proto/message-compiled.js
+++ b/proto/message-compiled.js
@@ -1,11 +1,13 @@
 module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['import']({
     "package": "push_server.messages",
+    "syntax": "proto2",
     "options": {
         "objc_class_prefix": "AVIM"
     },
     "messages": [
         {
             "name": "JsonObjectMessage",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "required",
@@ -17,6 +19,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "UnreadTuple",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "required",
@@ -41,11 +44,24 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "type": "int64",
                     "name": "timestamp",
                     "id": 4
+                },
+                {
+                    "rule": "optional",
+                    "type": "string",
+                    "name": "from",
+                    "id": 5
+                },
+                {
+                    "rule": "optional",
+                    "type": "string",
+                    "name": "data",
+                    "id": 6
                 }
             ]
         },
         {
             "name": "LogItem",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -76,15 +92,23 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "type": "int64",
                     "name": "ackAt",
                     "id": 5
+                },
+                {
+                    "rule": "optional",
+                    "type": "int64",
+                    "name": "readAt",
+                    "id": 6
                 }
             ]
         },
         {
             "name": "LoginCommand",
+            "syntax": "proto2",
             "fields": []
         },
         {
             "name": "DataCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "repeated",
@@ -108,6 +132,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "SessionCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -204,11 +229,18 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "type": "string",
                     "name": "detail",
                     "id": 16
+                },
+                {
+                    "rule": "optional",
+                    "type": "int64",
+                    "name": "lastUnreadNotifTime",
+                    "id": 17
                 }
             ]
         },
         {
             "name": "ErrorCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "required",
@@ -238,6 +270,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "DirectCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -322,11 +355,18 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "type": "string",
                     "name": "pushData",
                     "id": 16
+                },
+                {
+                    "rule": "optional",
+                    "type": "bool",
+                    "name": "will",
+                    "id": 17
                 }
             ]
         },
         {
             "name": "AckCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -398,17 +438,25 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "UnreadCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "repeated",
                     "type": "UnreadTuple",
                     "name": "convs",
                     "id": 1
+                },
+                {
+                    "rule": "optional",
+                    "type": "int64",
+                    "name": "notifTime",
+                    "id": 2
                 }
             ]
         },
         {
             "name": "ConvCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "repeated",
@@ -519,10 +567,22 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "id": 18
                 },
                 {
-                    "rule": "repeated",
+                    "rule": "optional",
                     "type": "string",
-                    "name": "members",
-                    "id": 19
+                    "name": "targetClientId",
+                    "id": 20
+                },
+                {
+                    "rule": "optional",
+                    "type": "int64",
+                    "name": "maxReadTimestamp",
+                    "id": 21
+                },
+                {
+                    "rule": "optional",
+                    "type": "int64",
+                    "name": "maxAckTimestamp",
+                    "id": 22
                 },
                 {
                     "rule": "optional",
@@ -546,6 +606,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "RoomCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -593,6 +654,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "LogsCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -649,6 +711,12 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "id": 9
                 },
                 {
+                    "rule": "optional",
+                    "type": "bool",
+                    "name": "reversed",
+                    "id": 10
+                },
+                {
                     "rule": "repeated",
                     "type": "LogItem",
                     "name": "logs",
@@ -658,6 +726,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "RcpCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -676,11 +745,18 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "type": "int64",
                     "name": "t",
                     "id": 3
+                },
+                {
+                    "rule": "optional",
+                    "type": "bool",
+                    "name": "read",
+                    "id": 4
                 }
             ]
         },
         {
             "name": "ReadTuple",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "required",
@@ -704,6 +780,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "ReadCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -727,6 +804,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "PresenceCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -750,6 +828,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "ReportCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "optional",
@@ -773,6 +852,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "GenericCommand",
+            "syntax": "proto2",
             "fields": [
                 {
                     "rule": "required",
@@ -906,6 +986,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
     "enums": [
         {
             "name": "CommandType",
+            "syntax": "proto2",
             "values": [
                 {
                     "name": "session",
@@ -971,6 +1052,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "OpType",
+            "syntax": "proto2",
             "values": [
                 {
                     "name": "open",
@@ -1077,6 +1159,10 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                     "id": 50
                 },
                 {
+                    "name": "max_read",
+                    "id": 51
+                },
+                {
                     "name": "join",
                     "id": 80
                 },
@@ -1116,6 +1202,7 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
         },
         {
             "name": "StatusType",
+            "syntax": "proto2",
             "values": [
                 {
                     "name": "on",
@@ -1127,5 +1214,6 @@ module.exports = require("protobufjs/dist/protobuf-light").newBuilder({})['impor
                 }
             ]
         }
-    ]
+    ],
+    "isNamespace": true
 }).build();

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -59,6 +59,7 @@ enum OpType {
   unmute = 48;
   status = 49;
   members = 50;
+  max_read = 51;
 
   // room
   join = 80;
@@ -92,6 +93,8 @@ message UnreadTuple {
   required int32 unread = 2;
   optional string mid = 3;
   optional int64 timestamp = 4;
+  optional string from = 5;
+  optional string data = 6;
 }
 
 message LogItem {
@@ -100,6 +103,7 @@ message LogItem {
   optional int64 timestamp = 3;
   optional string msgId = 4;
   optional int64 ackAt = 5;
+  optional int64 readAt = 6;
 }
 
 message LoginCommand {
@@ -128,6 +132,7 @@ message SessionCommand {
   optional string deviceToken = 14;
   optional bool sp = 15;
   optional string detail = 16;
+  optional int64 lastUnreadNotifTime = 17;
 }
 
 message ErrorCommand {
@@ -152,6 +157,7 @@ message DirectCommand {
   optional string dt = 14;
   optional string roomId = 15;
   optional string pushData = 16;
+  optional bool will = 17;
 }
 
 message AckCommand {
@@ -170,6 +176,7 @@ message AckCommand {
 
 message UnreadCommand {
   repeated UnreadTuple convs = 1;
+  optional int64 notifTime = 2;
 }
 
 message ConvCommand {
@@ -193,7 +200,9 @@ message ConvCommand {
   optional bool statusPub = 17;
   optional int32 statusTTL = 18;
 
-  repeated string members = 19;
+  optional string targetClientId = 20;
+  optional int64 maxReadTimestamp = 21;
+  optional int64 maxAckTimestamp = 22;
 
   optional JsonObjectMessage results = 100;
   optional JsonObjectMessage where = 101;
@@ -220,6 +229,7 @@ message LogsCommand {
   optional string mid = 7;
   optional string checksum = 8;
   optional bool stored = 9;
+  optional bool reversed = 10;
 
   repeated LogItem logs = 105;
 }
@@ -228,6 +238,7 @@ message RcpCommand {
   optional string id = 1;
   optional string cid = 2;
   optional int64 t = 3;
+  optional bool read = 4;
 }
 
 message ReadTuple {

--- a/realtime.d.ts
+++ b/realtime.d.ts
@@ -76,7 +76,7 @@ declare module LeanCloudRealtime {
     quit(): Promise<Conversation>;
     remove(clientIds: string[]): Promise<Conversation>;
     save(): Promise<Conversation>;
-    send(message: Message, options?: { pushData?: Object, priority?: MessagePriority, reciept?: boolean }): Promise<Message>;
+    send(message: Message, options?: { pushData?: Object, priority?: MessagePriority, receipt?: boolean }): Promise<Message>;
     set(key: string, value: any): Conversation;
     unmute(): Promise<Conversation>;
   }

--- a/src/messages/message.js
+++ b/src/messages/message.js
@@ -26,6 +26,7 @@ const rMessageStatus = {
   [MessageStatus.SENDING]: true,
   [MessageStatus.SENT]: true,
   [MessageStatus.DELIVERED]: true,
+  [MessageStatus.READ]: true,
   [MessageStatus.FAILED]: true,
 };
 
@@ -41,7 +42,7 @@ export default class Message {
        * @type {String}
        * @memberof Message#
        */
-      id: uuid.v4(),
+      id: uuid(),
       /**
        * 消息所在的 conversation id
        * @memberof Message#
@@ -64,7 +65,7 @@ export default class Message {
        * 标记需要回执
        * @memberof Message#
        * @type {Boolean}
-       * @deprecated 指定是否需要送达回执请使用 {@link Conversation#send} 方法的 `options.reciept` 参数。
+       * @deprecated 指定是否需要送达回执请使用 {@link Conversation#send} 方法的 `options.receipt` 参数。
        */
       needReceipt: false,
       /**
@@ -81,6 +82,12 @@ export default class Message {
        * @memberof Message#
        */
       // deliveredAt,
+      /**
+       * @var readAt {?Date} 消息被阅读时间
+       * @memberof Message#
+       * @since 3.4.0
+       */
+      // readAt,
     });
     this._setStatus(MessageStatus.NONE);
   }
@@ -89,10 +96,10 @@ export default class Message {
    * 设置是否需要送达回执
    * @param {Boolean} needReceipt
    * @return {Message} self
-   * @deprecated 请使用 {@link Conversation#send} 方法的 `options.reciept` 选项代替。
+   * @deprecated 请使用 {@link Conversation#send} 方法的 `options.receipt` 选项代替。
    */
   setNeedReceipt(needReceipt) {
-    console.warn('DEPRECATION Message#setNeedReceipt: Use Conversation#send with sendOptions.reciept instead.');
+    console.warn('DEPRECATION Message#setNeedReceipt: Use Conversation#send with sendOptions.receipt instead.');
     this.needReceipt = needReceipt;
     return this;
   }

--- a/src/realtime.js
+++ b/src/realtime.js
@@ -41,8 +41,9 @@ export default class Realtime extends EventEmitter {
       pushOfflineMessages: false,
       noBinary: isWeapp,
       ssl: true,
+      server: process.env.SERVER,
     }, options);
-    this._id = uuid.v4();
+    this._id = uuid();
     this._cache = new Cache('endpoints');
     this._clients = {};
     this._plugins = ensureArray(options.plugins).reduce(

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -13,8 +13,8 @@ export default class Cache {
     if (cache) {
       const value = cache.value;
       if (value !== Expirable.EXPIRED) {
-        debug('[%s] hit: %s %O', this.name, key, cache.value);
-        return cache.value;
+        debug('[%s] hit: %s %O', this.name, key, value);
+        return value;
       }
       delete this._map[key];
     }

--- a/test/im-client.js
+++ b/test/im-client.js
@@ -193,6 +193,14 @@ describe('IMClient', () => {
           conversations[0].lastMessage.should.be.instanceof(Message);
         })
     );
+    it('getConversations', () =>
+      client.getConversations([NON_EXISTING_ROOM_ID, EXISTING_ROOM_ID, EXISTING_ROOM_ID])
+        .then(([nonExistingConv, existingConv1, existingConv2]) => {
+          should(nonExistingConv).be.null();
+          existingConv1.id.should.eql(EXISTING_ROOM_ID);
+          existingConv2.should.be.exactly(existingConv1);
+        })
+    );
   });
 
   describe('createConversation', () => {

--- a/test/messages.js
+++ b/test/messages.js
@@ -245,6 +245,25 @@ describe('Messages', () => {
         .then(() => {
           message.status.should.eql(MessageStatus.DELIVERED);
           message.deliveredAt.should.be.Date();
+          conversationZwang.lastDeliveredAt.should.be.Date();
+        });
+    });
+    it('read', () => {
+      const message = new TextMessage('message needs receipt');
+      const readPromise = listen(conversationZwang, 'lastreadatupdate');
+      conversationWchen.on('message', (msg) => {
+        if (msg.id === message.id) conversationWchen.markAsRead();
+      });
+      message.setNeedReceipt(true);
+      return conversationZwang.send(message)
+        .then(() => readPromise)
+        .then(() => {
+          conversationZwang.lastReadAt.should.be.Date();
+        })
+        .then(() => conversationZwang.fetchReceiptTimestamps())
+        .then((conv) => {
+          conv.lastDeliveredAt.should.be.Date();
+          conv.lastReadAt.should.be.Date();
         });
     });
     it('errors', () => {


### PR DESCRIPTION
add Conversation#read
deprecate Conversation#markAsRead
deprecate IMClient.markAllAsRead

add Conversation#fetchReceiptTimestamps

add Conversation#event:lastdeliveredatupdate
add Conversation#event:lastreadatupdate
deprecate Conversation#event:receipt

implement https://github.com/leancloud/avoscloud-push/issues/675#issuecomment-282961128

还修正了 sendOption.reciept 参数的拼写错误，简直尴尬。