### PR TITLE
fix(WebScoketPlus): emit disconnect event before offline

### DIFF
--- a/src/websocket-plus.js
+++ b/src/websocket-plus.js
@@ -112,7 +112,7 @@ class WebSocketPlus extends EventEmitter {
       this.emit('disconnect');
     }
   }
-  onbeforepause() {
+  onpause() {
     this.emit('offline');
   }
   onbeforeresume() {

--- a/test/websocket-plus.js
+++ b/test/websocket-plus.js
@@ -92,19 +92,17 @@ describe('WebSocketPlus', () => {
       if (!ws.is('closed')) ws.close();
     });
     it('should emit offline-disconnect-online-schedule in order', () => {
-      const offlineCallback = sinon.spy();
-      ws.on('offline', offlineCallback);
-      const onlineCallback = sinon.spy();
-      ws.on('online', onlineCallback);
-      const listenDisconnect = listen(ws, 'disconnect');
+      const events = [];
+      ['disconnect', 'offline', 'online', 'schedule'].forEach(event => ws.on(event, () => events.push(event)));
+      const listenOffline = listen(ws, 'offline');
       const listenSchedule = listen(ws, 'schedule');
       ws.pause();
-      return listenDisconnect.then(() => {
-        offlineCallback.should.be.calledOnce();
+      return listenOffline.then(() => {
+        events.should.eql(['disconnect', 'offline']);
         ws.resume();
         return listenSchedule;
       }).then(() => {
-        onlineCallback.should.be.calledOnce();
+        events.should.eql(['disconnect', 'offline', 'online', 'schedule']);
       });
     });
   });


### PR DESCRIPTION
之前如果网络断开再恢复，派发的事件的顺序是 ['offline', 'disconnect', 'online', 'schedule']
用户如果分别对 'disconnect', 'offline' 进行 UI 上的更新的话，最终看到的会是 disconnect 的提示。
调整成 ['disconnect', 'offline', 'online', 'schedule'] 会让 UI 的工作更简单。