### PR TITLE
refactor(unread): filter unread events which not accutally changed

### DIFF
--- a/src/conversation.js
+++ b/src/conversation.js
@@ -112,17 +112,12 @@ export default class Conversation extends EventEmitter {
     });
     this._attributes = attributes;
     this._reset();
-    /**
-     * 当前用户在该对话的未读消息数
-     * @memberof Conversation#
-     * @type {Number}
-     */
-    this.unreadMessagesCount = 0;
     this.members = Array.from(new Set(this.members));
     Object.assign(internal(this), {
       messagesWaitingForReceipt: {},
       lastDeliveredAt: null,
       lastReadAt: null,
+      unreadMessagesCount: 0,
     });
     if (client instanceof IMClient) {
       this._client = client;
@@ -143,6 +138,20 @@ export default class Conversation extends EventEmitter {
     ));
     // onConversationCreate hook
     applyDecorators(this._client._plugins.onConversationCreate, this);
+  }
+
+  set unreadMessagesCount(value) {
+    if (value !== this.unreadMessagesCount) {
+      internal(this).unreadMessagesCount = value;
+      this._client.emit('unreadmessagescountupdate', this);
+    }
+  }
+  /**
+   * 当前用户在该对话的未读消息数
+   * @type {Number}
+   */
+  get unreadMessagesCount() {
+    return internal(this).unreadMessagesCount;
   }
 
   set createdAt(value) {

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -16,7 +16,7 @@ import {
   CLIENT_ID,
 } from './configs';
 
-import { hold, listen, sinon } from './test-utils';
+import { listen, sinon } from './test-utils';
 
 describe('Conversation', () => {
   let realtime;
@@ -413,17 +413,6 @@ describe('Conversation', () => {
             conv.lastMessage.id.should.eql(message.id);
           }),
         ]);
-      })
-      .then(() => {
-        bwangRealtime.pause();
-        bwangRealtime.resume();
-        const updateEventCallback = sinon.spy();
-        bwang0.on('unreadmessagescountupdate', updateEventCallback);
-        return listen(bwang0, 'reconnect')
-          .then(hold(1000))
-          .then(() => {
-            updateEventCallback.should.not.be.called();
-          });
       })
       .then(() => realtime.createIMClient(bwangId))
       .then(bwang1 => listen(bwang1, 'unreadmessagescountupdate')


### PR DESCRIPTION
让 `unreadmessagescountupdate` 事件更加贴合其意思，主要做了两件事：

1. 过滤掉了 Conversation 的 unreadMessagesCount 没有变化的情况
2. 当收到在线消息时，也派发 `unreadmessagescountupdate` 事件