### PR TITLE
fix: skip handling synced outgoing messages

### DIFF
--- a/src/im-client.js
+++ b/src/im-client.js
@@ -360,9 +360,12 @@ export default class IMClient extends Client {
       message._setStatus(MessageStatus.SENT);
       conversation.lastMessage = message; // eslint-disable-line no-param-reassign
       conversation.lastMessageAt = message.timestamp; // eslint-disable-line no-param-reassign
-      conversation.unreadMessagesCount += 1; // eslint-disable-line no-param-reassign
-      if (!(transient || conversation.transient)) {
-        this._sendAck(message);
+      // filter outgoing message sent from another device
+      if (message.from !== this.id) {
+        conversation.unreadMessagesCount += 1; // eslint-disable-line no-param-reassign
+        if (!(transient || conversation.transient)) {
+          this._sendAck(message);
+        }
       }
       /**
        * 当前用户收到消息


### PR DESCRIPTION
如果收到当前 client 其他设备发送的 message，需要跳过：

- 未读消息数累加
- 发送 ack

其他行为，包括派发 message 事件，保持不变。