### PR TITLE
fix(Read): only update Conversation#lastMessageAt with a later timestamp

### DIFF
--- a/src/conversation.js
+++ b/src/conversation.js
@@ -174,7 +174,9 @@ export default class Conversation extends EventEmitter {
     return this._updatedAt;
   }
   set lastMessageAt(value) {
-    this._lastMessageAt = decodeDate(value);
+    const time = decodeDate(value);
+    if (time <= this._lastMessageAt) return;
+    this._lastMessageAt = time;
   }
   get lastMessageAt() {
     return this._lastMessageAt;


### PR DESCRIPTION
fix an issue that the last message will not be marked as read caused by inaccurate lm.

cc @ylgrgyq 