### PR TITLE
fix(IMClient): delete client when failed opening

### DIFF
--- a/src/plugin-im.js
+++ b/src/plugin-im.js
@@ -180,6 +180,9 @@ const onRealtimeCreate = (realtime) => {
           realtime._IMClients[client.id] = client;
           realtime._register(client);
           return client;
+        }).catch((error) => {
+          delete realtime._IMClients[client.id];
+          throw error;
         });
     });
     if (idIsString) {


### PR DESCRIPTION
为了实现 createIMClient 的单例模式，设置了一个 map 来存正在 open 或已经 open 的 clients。但是在 open 失败的时候没有正确的删除对应恩 client 导致后续的 create 都会得到这个失败的结果。

https://leanticket.cn/tickets/13357