### PR TITLE
feat(IMClient): support createIMClient with an AV.User

### DIFF
--- a/demo/simple-chatroom/index.html
+++ b/demo/simple-chatroom/index.html
@@ -14,15 +14,22 @@
 <body>
   <h1>欢迎使用 LeanCloud 实时通信 SDK</h1>
   <div class="item">
-    <p>SDK 详细使用方法，请看官方文档</p>
     <p>
-      <a target="_blank" href="https://leancloud.cn/docs/js_realtime.html">https://leancloud.cn/docs/js_realtime.html</a>
+      <a target="_blank" href="https://leancloud.cn/docs/realtime_guide-js.html">使用文档</a> / 
+      <a target="_blank" href="https://leancloud.github.io/js-realtime-sdk/docs/">API 文档</a>
     </p>
   </div>
   <div class="item">
-    <label>您的昵称：</label>
-    <input autofocus id="input-name" type="text">
-    <div id="open-btn" class="btn">连接服务器</div>
+    <label>
+      用户名
+      <input autofocus id="input-name" type="text" value="Guest">
+    </label>
+    <label>
+      密码
+      <input autofocus id="input-password" type="password" value="Guest">
+    </label>
+    <div id="login-btn" class="btn">登录</div>
+    <div id="signup-btn" class="btn">注册</div>
   </div>
   <div class="item">
     <div id="print-wall" class="print-wall"></div>

--- a/plugins/live-query/test/index.js
+++ b/plugins/live-query/test/index.js
@@ -1,10 +1,11 @@
 import uuid from 'uuid/v4';
-import { APP_ID, REGION } from '../../../test/configs';
+import { APP_ID, APP_KEY, REGION } from '../../../test/configs';
 import { Realtime } from '../../../src/core';
 import { LiveQueryPlugin } from '../src/';
 
 const realtime = new Realtime({
   appId: APP_ID,
+  appKey: APP_KEY,
   region: REGION,
   plugins: [LiveQueryPlugin],
 });

--- a/src/im-client.js
+++ b/src/im-client.js
@@ -548,7 +548,7 @@ export default class IMClient extends EventEmitter {
           deviceId,
         }));
         if (this.options.signatureFactory) {
-          return runSignatureFactory(this.options.signatureFactory, [this.id])
+          return runSignatureFactory(this.options.signatureFactory, [this._identity])
             .then((signatureResult) => {
               Object.assign(command.sessionMessage, keyRemap({
                 signature: 's',
@@ -574,6 +574,7 @@ export default class IMClient extends EventEmitter {
           return;
         }
         this.id = peerId;
+        if (!this._identity) this._identity = peerId;
         if (token) {
           internal(this).sessionToken = new Expirable(token, tokenTTL * 1000);
         }
@@ -813,7 +814,7 @@ export default class IMClient extends EventEmitter {
     });
 
     if (this.options.conversationSignatureFactory) {
-      const params = [null, this.id, members, 'create'];
+      const params = [null, this._identity, members, 'create'];
       const signatureResult = await runSignatureFactory(
         this.options.conversationSignatureFactory,
         params,

--- a/src/signature-factory-runner.js
+++ b/src/signature-factory-runner.js
@@ -24,7 +24,7 @@ function _validateSignature(signatureResult = {}) {
 export default (signatureFactory, params) =>
   Promise.resolve()
     .then(() => {
-      debug(`call signatureFactory with ${params}`);
+      debug('call signatureFactory with %O', params);
       return signatureFactory(...params);
     })
     .then(

--- a/test/conversation-query.js
+++ b/test/conversation-query.js
@@ -4,6 +4,7 @@ import Message, { MessageStatus } from '../src/messages/message';
 
 import {
   APP_ID,
+  APP_KEY,
   REGION,
   EXISTING_ROOM_ID,
 } from './configs';
@@ -15,8 +16,8 @@ describe('ConversationQuery', () => {
     before(() =>
       new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
       })
         .createIMClient()
         .then((c) => { client = c; }),
@@ -173,8 +174,8 @@ describe('ConversationQuery', () => {
     before(() =>
       new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
       })
         .createIMClient()
         .then((c) => { client = c; }),

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -11,6 +11,7 @@ import { defineConversationProperty } from '../src/plugin-im';
 
 import {
   APP_ID,
+  APP_KEY,
   REGION,
   EXISTING_ROOM_ID,
   SYS_CONV_ID,
@@ -26,6 +27,7 @@ describe('Conversation', () => {
   before(() => {
     realtime = new Realtime({
       appId: APP_ID,
+      appKey: APP_KEY,
       region: REGION,
     });
     return realtime.createIMClient(CLIENT_ID)
@@ -393,6 +395,7 @@ describe('Conversation', () => {
       ).then(() => {
         bwangRealtime = new Realtime({
           appId: APP_ID,
+          appKey: APP_KEY,
           region: REGION,
         });
         return bwangRealtime.createIMClient(bwangId);

--- a/test/im-client.js
+++ b/test/im-client.js
@@ -11,6 +11,7 @@ import { sinon, listen, series } from './test-utils';
 
 import {
   APP_ID,
+  APP_KEY,
   REGION,
   EXISTING_ROOM_ID,
   NON_EXISTING_ROOM_ID,
@@ -23,8 +24,8 @@ describe('IMClient', () => {
   before(() => {
     realtime = new Realtime({
       appId: APP_ID,
+      appKey: APP_KEY,
       region: REGION,
-      pushUnread: false,
     });
     return realtime
       .createIMClient(CLIENT_ID)
@@ -37,8 +38,8 @@ describe('IMClient', () => {
     it('normal create and close', () => {
       const rt = new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
       });
       const closeCallback = sinon.spy();
       return Promise.all([
@@ -95,8 +96,8 @@ describe('IMClient', () => {
           client1.on('conflict', () => done());
           return new Realtime({
             appId: APP_ID,
+            appKey: APP_KEY,
             region: REGION,
-            pushUnread: false,
           }).createIMClient(ID, undefined, 'TEST')
             .then(client2 => client2.close());
         }).catch(done);

--- a/test/messages.js
+++ b/test/messages.js
@@ -17,6 +17,7 @@ import { listen, hold, sinon } from './test-utils';
 
 import {
   APP_ID,
+  APP_KEY,
   REGION,
   EXISTING_ROOM_ID,
 } from './configs';
@@ -135,8 +136,8 @@ describe('Messages', () => {
     before(() => {
       const realtime = new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
       });
       return Promise.all([
         realtime.createIMClient(),

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -9,6 +9,7 @@ import { sinon, hold } from './test-utils';
 
 import {
   APP_ID,
+  APP_KEY,
   REGION,
   EXISTING_ROOM_ID,
   CLIENT_ID,
@@ -28,8 +29,8 @@ describe('Plugin', () => {
     before(() => {
       realtime = new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
         plugins: [{
           messageClasses: [PluginDefinedMessage],
           onRealtimeCreate: patchTestFunction(),
@@ -86,8 +87,8 @@ describe('Plugin', () => {
     before(() => {
       realtime = new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
         plugins: [{
           onRealtimeCreate: patchTestFunction(1),
           beforeMessageParse: json => Object.assign({}, json, {
@@ -128,8 +129,8 @@ describe('Plugin', () => {
     it('create Realtime should throw', () => {
       (() => new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
         plugins: [{
           name: 'ErrorPlugin',
           onRealtimeCreate: () => {
@@ -141,8 +142,8 @@ describe('Plugin', () => {
     it('create IMClient should be rejected', () =>
       new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
         plugins: [{
           name: 'ErrorPlugin',
           onIMClientCreate: () => {
@@ -154,8 +155,8 @@ describe('Plugin', () => {
     it('middleware error should be reported', () =>
       new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
         plugins: [{
           name: 'ErrorPlugin',
           beforeMessageParse: () => {
@@ -168,8 +169,8 @@ describe('Plugin', () => {
     it('beforeMessageDispatch error should be reported', () =>
       new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
         region: REGION,
-        pushUnread: false,
         plugins: [{
           name: 'ErrorPlugin',
           beforeMessageDispatch: () => {
@@ -187,8 +188,8 @@ describe('Plugin', () => {
       return Promise.all([
         new Realtime({
           appId: APP_ID,
+          appKey: APP_KEY,
           region: REGION,
-          pushUnread: false,
           plugins: [{
             name: 'ErrorPlugin',
             beforeMessageParse: () => Promise.resolve(),
@@ -196,8 +197,8 @@ describe('Plugin', () => {
         })._messageParser.parse(new TextMessage('1').toJSON()),
         new Realtime({
           appId: APP_ID,
+          appKey: APP_KEY,
           region: REGION,
-          pushUnread: false,
           plugins: [{
             name: 'ErrorPlugin',
             beforeMessageParse: () => 1,

--- a/test/realtime.js
+++ b/test/realtime.js
@@ -10,14 +10,15 @@ import { listen, sinon } from './test-utils';
 
 import {
   APP_ID,
+  APP_KEY,
   REGION,
   NON_EXISTING_ROOM_ID,
 } from './configs';
 
 const createRealtime = options => new Realtime(Object.assign({
   appId: APP_ID,
+  appKey: APP_KEY,
   region: REGION,
-  pushUnread: false,
 }, options));
 
 class Client {}
@@ -30,6 +31,7 @@ describe('Realtime', () => {
     it('normal', () =>
       (() => new Realtime({
         appId: APP_ID,
+        appKey: APP_KEY,
       })).should.not.throw,
     );
   });
@@ -206,7 +208,7 @@ describe('Connection', () => {
     })).should.be.rejectedWith('CONVERSATION_UPDATE_REJECTED'),
   );
   it('message dispatch', () => {
-    const clientMessageEventCallback = sinon.stub(client, '_dispatchCommand');
+    const clientMessageEventCallback = sinon.spy(client, '_dispatchCommand');
     connection.emit('message', new GenericCommand({
       cmd: 1,
     }));


### PR DESCRIPTION
用户能感知到的变动：
- 初始化 Realtime 必须提供 appKey
- Realtime#createIMClient 接收 AV.User 为第一个参数
- 更新到了 AppRouter 2，域名变了

内部变动：
- 增加了 realtime#_request
- 因为验证签名的开关会影响现有的 case，这个功能不太好测试，因此新建了一个应用更新了 demo/simple-chatroom。