### PR TITLE
fix(IM): block commands until IMClient initialized

### DIFF
--- a/src/plugin-im.js
+++ b/src/plugin-im.js
@@ -197,7 +197,7 @@ const beforeCommandDispatch = (command, realtime) => {
   if (command.peerId === null) return true;
   const targetClient = realtime._IMClients[command.peerId];
   if (targetClient) {
-    Promise.resolve(targetClient._dispatchCommand(command)).catch(debug);
+    Promise.resolve(targetClient).then(client => client._dispatchCommand(command)).catch(debug);
   } else {
     debug(
       '[WARN] Unexpected message received without any live client match: %O',

--- a/test/realtime.js
+++ b/test/realtime.js
@@ -6,7 +6,7 @@ import Connection from '../src/connection';
 import { GenericCommand, CommandType, ConvCommand } from '../proto/message';
 import TextMessage from '../src/messages/text-message';
 
-import { listen, sinon } from './test-utils';
+import { listen, sinon, wait } from './test-utils';
 
 import {
   APP_ID,
@@ -220,7 +220,7 @@ describe('Connection', () => {
       peerId: client.id,
     });
     connection.emit('message', validMessage);
-    return Promise.resolve().then(() => {
+    return wait(0).then(() => {
       clientMessageEventCallback.should.be.calledOnce();
       clientMessageEventCallback.should.be.calledWith(validMessage);
       clientMessageEventCallback.restore();


### PR DESCRIPTION
sometimes unread/direct commands will be dispatched before client initialized.