### PR TITLE
fix: type definition of messageType & messageField

### DIFF
--- a/realtime.d.ts
+++ b/realtime.d.ts
@@ -566,16 +566,12 @@ declare interface PatchReason {
   detail?: string;
 }
 
-export type MessageDecorator<T extends AVMessage> = (
-  target: MessageConstructor<T>
-) => MessageConstructor<T>;
+export type TypedMessageDecorator = (
+  target: typeof TypedMessage
+) => typeof TypedMessage;
 
-export function messageType<T extends AVMessage>(
-  type: number
-): MessageDecorator<T>;
-export function messageField<T extends AVMessage>(
-  fields: string[]
-): MessageDecorator<T>;
+export function messageType(type: number): TypedMessageDecorator;
+export function messageField(fields: string[]): TypedMessageDecorator;
 export function IE10Compatible<T extends AVMessage>(
   target: MessageConstructor<T>
 ): MessageConstructor<T>;


### PR DESCRIPTION
相关工单: https://www.leanticket.cn/tickets/36979

之前的定义约束不够，缺少 Message.parse 、Message.validate 和 TypedMessage.TYPE 。

看了下 helpers.js 里这两个函数的用法，只要求 target 是 TypedMessage Class 即可（文档里也是这么说的），就把泛型参数去掉了。