### PR TITLE
fix(signature): unify action name and param order

### DIFF
--- a/realtime.d.ts
+++ b/realtime.d.ts
@@ -36,14 +36,14 @@ export class Realtime extends EventEmitter<ConnectionEvent> {
     options?: {
       signatureFactory?: (clientId: string) => SignatureFactoryResult;
       conversationSignatureFactory?: (
-        clientId: string,
         conversationId: string,
+        clientId: string,
         targetIds: string[],
         action: string
       ) => SignatureFactoryResult;
       blacklistSignatureFactory?: (
-        clientId: string,
         conversationId: string,
+        clientId: string,
         targetIds: string[],
         action: string
       ) => SignatureFactoryResult;

--- a/src/conversations/persistent-conversation.js
+++ b/src/conversations/persistent-conversation.js
@@ -335,7 +335,7 @@ class PersistentConversation extends ConversationBase {
 
   async _appendBlacklistSignature(command, action, clientIds) {
     if (this._client.options.blacklistSignatureFactory) {
-      const params = [this._client.id, this.id, clientIds.sort(), action];
+      const params = [this.id, this._client.id, clientIds.sort(), action];
       const signatureResult = await runSignatureFactory(
         this._client.options.blacklistSignatureFactory,
         params
@@ -370,7 +370,7 @@ class PersistentConversation extends ConversationBase {
         m: clientIds,
       }),
     });
-    await this._appendConversationSignature(command, 'add', clientIds);
+    await this._appendConversationSignature(command, 'invite', clientIds);
     const {
       convMessage,
       convMessage: { allowedPids },
@@ -395,7 +395,7 @@ class PersistentConversation extends ConversationBase {
         m: clientIds,
       }),
     });
-    await this._appendConversationSignature(command, 'remove', clientIds);
+    await this._appendConversationSignature(command, 'kick', clientIds);
     const {
       convMessage,
       convMessage: { allowedPids },

--- a/test/conversation.js
+++ b/test/conversation.js
@@ -205,7 +205,7 @@ describe('Conversation', () => {
             this.conversation.id,
             'ycui',
             ['jwu', 'wduan'],
-            'add',
+            'invite',
           ]);
       });
     });
@@ -217,7 +217,7 @@ describe('Conversation', () => {
             this.conversation.id,
             'ycui',
             ['wduan'],
-            'remove',
+            'kick',
           ]);
       });
     });


### PR DESCRIPTION
- add/remove action is renamed to invite/kick  to align with the document (This is breaking for users of conversation signature).
- swap the clientId and the convId param for blacklistSignatureFactory (This is breaking for users of blacklist signature).
- fix the conversationSignature order in ts definition.

close https://www.leanticket.cn/tickets/37033