### PR TITLE
feat(im-client): support omit peer id

### DIFF
--- a/src/im-client.js
+++ b/src/im-client.js
@@ -78,9 +78,11 @@ const isTemporaryConversatrionId = id => /^_tmp:/.test(id);
  * 1 transient-msg-ack
  * 1 keep-notification
  * 1 partial-failed-msg
+ * 0 group-chat-rcp
+ * 1 omit-peer-id
  * @ignore
  */
-const configBitmap = 0b111011;
+const configBitmap = 0b10111011;
 
 export default class IMClient extends EventEmitter {
   /**
@@ -820,7 +822,6 @@ export default class IMClient extends EventEmitter {
         const timestamps = convAckMessages.map(message => message.timestamp);
         const command = new GenericCommand({
           cmd: 'ack',
-          peerId: this.id,
           ackMessage: new AckCommand({
             cid,
             fromts: Math.min.apply(null, timestamps),


### PR DESCRIPTION
See: leancloud/rfcs#1089

JS 的实现方式：

JS SDK 中没有「默认 peerId」这个概念，创建 IMClient 时设置了 clientId 就用它当 peerId ，未设置 clientId 时使用后端返回的 peerId 。

若 Connection 中仅有一个 IMClient ，发送命令时省略 peerId（之前发送 ACK 时还是会带上，这次也去掉了），若有多个 IMClient 则不省略 peerId 。

收到的命令如果携带 peerId 就将其派发给对应的 IMClient ，否则派发给第一个创建的 IMClient 。