### PR TITLE
fix: type definition of IMClient#getConversation

### DIFF
--- a/realtime.d.ts
+++ b/realtime.d.ts
@@ -77,7 +77,10 @@ declare class IMClient extends EventEmitter<ClientEvent | SharedEvent> {
     members?: string[];
     ttl?: number;
   }): Promise<TemporaryConversation>;
-  getConversation(id: string, noCache?: boolean): Promise<ConversationBase>;
+  getConversation(
+    id: string,
+    noCache?: boolean
+  ): Promise<PresistentConversation>;
   getQuery(): ConversationQuery<PresistentConversation>;
   getServiceConversationQuery(): ConversationQuery<ServiceConversation>;
   getChatRoomQuery(): ConversationQuery<ChatRoom>;


### PR DESCRIPTION
感觉这里定义错了，`IMClient#getConversation` 返回 `IMClient#getQuery` 的查询结果，所以应该也是 `PresistentConversation`