### PR TITLE
feat(plugin/typed-messages): auto init in browser

### DIFF
--- a/plugins/typed-messages/src/index.js
+++ b/plugins/typed-messages/src/index.js
@@ -60,3 +60,8 @@ export default function initPlugin(AV, IM) {
     LocationMessage,
   };
 }
+
+// 浏览器环境下自动初始化
+if (typeof self !== 'undefined' && self.AV) {
+  Object.assign(self.AV, initPlugin(self.AV, self.AV));
+}

--- a/plugins/typed-messages/src/index.js
+++ b/plugins/typed-messages/src/index.js
@@ -1,3 +1,5 @@
+/* global window */
+
 /** @module leancloud-realtime-plugin-typed-messages */
 
 import createFileMessageClass from './file-message';
@@ -62,6 +64,6 @@ export default function initPlugin(AV, IM) {
 }
 
 // 浏览器环境下自动初始化
-if (typeof self !== 'undefined' && self.AV) {
-  Object.assign(self.AV, initPlugin(self.AV, self.AV));
+if (typeof window !== 'undefined' && window.AV) {
+  Object.assign(window.AV, initPlugin(window.AV, window.AV));
 }

--- a/rollup/rollup.config.plugins.js
+++ b/rollup/rollup.config.plugins.js
@@ -5,7 +5,7 @@ import commonjs from '@rollup/plugin-commonjs';
 
 import { withMinified, babelConfig } from './shared-configs';
 
-const createConfig = ({ input, output, id }) => ({
+const createConfig = ({ input, output, id, name = 'AV' }) => ({
   input,
   external: [
     'leancloud-realtime',
@@ -15,7 +15,7 @@ const createConfig = ({ input, output, id }) => ({
   output: {
     file: output,
     format: 'umd',
-    name: 'AV',
+    name,
     extend: true,
     amd: {
       id,
@@ -46,6 +46,7 @@ const typedMessages = createConfig({
   input: 'plugins/typed-messages/src/index.js',
   output: 'plugins/typed-messages/dist/typed-messages.js',
   id: 'typed-messages',
+  name: 'AV.initTypedMessages',
 });
 const webrtc = createConfig({
   input: 'plugins/webrtc/src/index.js',


### PR DESCRIPTION
在浏览器中，富媒体消息插件默认导出的初始化函数会覆盖由存储 SDK（或 IM SDK）设置的 AV 命名空间。

最初没想到这一点，这个改法算是抢救一下吧。但确实挺好用的。