### PR TITLE
fix: test app server

### DIFF
--- a/plugins/typed-messages/test/index.js
+++ b/plugins/typed-messages/test/index.js
@@ -1,5 +1,5 @@
 import AV from 'leancloud-storage';
-import { APP_ID, APP_KEY } from '../../../test/configs';
+import { APP_ID, APP_KEY, SERVER } from '../../../test/configs';
 
 import './file-message-and-subclasses';
 import './location-message';
@@ -7,4 +7,5 @@ import './location-message';
 AV.init({
   appId: APP_ID,
   appKey: APP_KEY,
+  serverURLs: SERVER,
 });

--- a/test/configs.js
+++ b/test/configs.js
@@ -6,7 +6,7 @@ export const APP_ID =
 export const APP_KEY =
   process.env.APP_KEY || 'xhiibo2eiyokjdu2y3kqcb7334rtw4x33zam98buxzkjuq5g';
 const defaultServer = isCNApp(APP_ID)
-  ? 'https://xhiibo2e.lc-cn-n1-shared.com'
+  ? 'https://anruhhk6.lc-cn-n1-shared.com'
   : undefined;
 export const SERVER = process.env.SERVER ? process.env.SERVER : defaultServer;
 export const EXISTING_ROOM_ID =


### PR DESCRIPTION
之前测试应用的域名证书过期了，就换成共享域名继续使用了。但设置错了，应该用 appId 的前 8 位结果设置成 appKey 的前 8 位了。神奇的是测试用例都能跑过。

富媒体消息的测试用的是 3.x 的存储 SDK，会自动根据 appId 使用共享域名，但自动拼接的 https://xxxxxxxx.api.lncld.net 的域名现在也不能用了。也手动设置一下 serverURLs 罢。